### PR TITLE
Fix dotnet publish issue with X11 and Wayland libglfw.so

### DIFF
--- a/download_dependencies.ps1
+++ b/download_dependencies.ps1
@@ -1,7 +1,5 @@
-Param([parameter(Mandatory=$true,Position=0)][String]$GLFW_VERSION)
-
-# The built .so file will end in .so.3.3 for a version like 3.3.7, to get the correct file we need to pass "3.3" Rename-Item for wayland
-[String]$GLFW_SHORT_VERSION = $GLFW_VERSION.Substring(0, $GLFW_VERSION.LastIndexOf("."))
+Param([parameter(Mandatory=$true,Position=0)][String]$GLFW_VERSION,
+      [parameter(Mandatory=$true,Position=1)][String]$GLFW_SHORT_VERSION)
 
 New-Item -ItemType Directory -Force -Path tmp
 

--- a/download_dependencies.ps1
+++ b/download_dependencies.ps1
@@ -65,7 +65,7 @@ if ($LastExitCode -ne 0) {
 
 make -j
 
-Rename-Item -Path "src/libglfw.so.3.3" -NewName "libglfw-wayland.so.$GLFW_SHORT_VERSION"
+Rename-Item -Path "src/libglfw.so.$GLFW_SHORT_VERSION" -NewName "libglfw-wayland.so.$GLFW_SHORT_VERSION"
 if ($LastExitCode -ne 0) {
     throw 'GLFW Wayland compilation failed'
 }

--- a/download_dependencies.ps1
+++ b/download_dependencies.ps1
@@ -1,5 +1,8 @@
 Param([parameter(Mandatory=$true,Position=0)][String]$GLFW_VERSION)
 
+# The built .so file will end in .so.3.3 for a version like 3.3.7, to get the correct file we need to pass "3.3" Rename-Item for wayland
+[String]$GLFW_SHORT_VERSION = $GLFW_VERSION.Substring(0, $GLFW_VERSION.LastIndexOf("."))
+
 New-Item -ItemType Directory -Force -Path tmp
 
 try{
@@ -62,6 +65,7 @@ if ($LastExitCode -ne 0) {
 
 make -j
 
+Rename-Item -Path "src/libglfw.so.3.3" -NewName "libglfw-wayland.so.$GLFW_SHORT_VERSION"
 if ($LastExitCode -ne 0) {
     throw 'GLFW Wayland compilation failed'
 }

--- a/glfw-redist.csproj
+++ b/glfw-redist.csproj
@@ -44,7 +44,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="tmp/src/build-wayland/src/*.so.$(GLFW_SHORT_VERSION)">
-      <PackagePath>runtimes/linux-x64/native/wayland/</PackagePath>
+      <PackagePath>runtimes/linux-x64/native/</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/make_nuget.ps1
+++ b/make_nuget.ps1
@@ -14,7 +14,7 @@ if($currentBranch -eq "develop") {
     $buildVersionResult = "0-pre" + (Get-Date).ToUniversalTime().ToString("yyyyMMddHHmmss")
 }
 
-./download_dependencies.ps1 $GLFW_VERSION
+./download_dependencies.ps1 $GLFW_VERSION $GLFW_SHORT_VERSION
 
 
 $header = Get-Content([System.IO.Path]::Combine($projectDir, ".\tmp\src\include\GLFW\glfw3.h")) | Out-String


### PR DESCRIPTION
Fixes an issue when an OpenTK app is published using `dotnet publish  --self-contained -r linux-x64 -f net6.0` both libraries (glwf x11 and wayland) would end up in the same output directory causing https://github.com/opentk/opentk/issues/1622

