### PR TITLE
Change build image to debian:oldoldstable to lower GLIBC requierment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,36 +10,37 @@ on:
 jobs:
   build:
     env:
-      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        
     runs-on: ubuntu-latest
     container: debian:oldoldstable
     strategy:
       fail-fast: true
 
     steps:
-      - name: Install X11 dependencies
-        run: |
-          apt-get update
-          apt-get install -y xorg-dev libwayland-dev libxkbcommon-dev wayland-protocols extra-cmake-modules
-      - name: Install build dependencies
-        run: |
-          apt-get install -y curl wget git cmake
-          VERSION_ID=$(awk -F= '/^VERSION_ID=/{gsub(/"/, "", $2); print $2}' /etc/os-release)
-          wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
-          dpkg -i packages-microsoft-prod.deb
-          apt-get update
-          apt-get install -y powershell
-      - uses: actions/checkout@v3
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.0.x
-      - name: Download dependencies and create Nuget Package
-        run: ./make_nuget.ps1 "" ${{ github.run_number }}
-        shell: pwsh
-      - uses: actions/upload-artifact@v3
-        with:
-          name: NugetPackage
-          path: ./artifacts/*.nupkg
-      - name: Deploy Nuget Package
-        run: dotnet nuget push ./artifacts/*.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
+    - name: Install X11 dependencies
+      run: |
+        apt-get update
+        apt-get install -y xorg-dev libwayland-dev libxkbcommon-dev wayland-protocols extra-cmake-modules
+    - name: Install build dependencies
+      run: |
+        apt-get install -y curl wget git cmake
+        VERSION_ID=$(awk -F= '/^VERSION_ID=/{gsub(/"/, "", $2); print $2}' /etc/os-release)
+        wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
+        dpkg -i packages-microsoft-prod.deb
+        apt-get update
+        apt-get install -y powershell
+    - uses: actions/checkout@v3
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Download dependencies and create Nuget Package
+      run: ./make_nuget.ps1 "" ${{ github.run_number }}
+      shell: pwsh
+    - uses: actions/upload-artifact@v3
+      with:
+        name: NugetPackage
+        path: ./artifacts/*.nupkg
+    - name: Deploy Nuget Package
+      run: dotnet nuget push ./artifacts/*.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,13 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - name: Install dependencies
+      - name: Install X11 dependencies
         run: |
           apt-get update
-          apt-get install -y xorg-dev libwayland-dev libxkbcommon-dev wayland-protocols extra-cmake-modules curl wget git cmake
+          apt-get install -y xorg-dev libwayland-dev libxkbcommon-dev wayland-protocols extra-cmake-modules
+      - name: Install build dependencies
+        run: |
+          apt-get install -y curl wget git cmake
           wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/powershell_7.4.0-1.deb_amd64.deb
           dpkg -i powershell_7.4.0-1.deb_amd64.deb
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     env:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    runs-on: ubuntu-latest
     container: debian:oldoldstable
     strategy:
       fail-fast: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,30 +10,33 @@ on:
 jobs:
   build:
     env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    
     runs-on: ${{ matrix.os }}
+    container: debian:oldoldstable
     strategy:
       fail-fast: true
-      matrix: 
+      matrix:
         os: [ubuntu-latest]
 
     steps:
-    - name: Install X11 dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install xorg-dev libwayland-dev libxkbcommon-dev wayland-protocols extra-cmake-modules
-    - uses: actions/checkout@v3
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    - name: Download dependencies and create Nuget Package
-      run: ./make_nuget.ps1 "" ${{ github.run_number }}
-      shell: pwsh
-    - uses: actions/upload-artifact@v3
-      with:
-        name: NugetPackage
-        path: ./artifacts/*.nupkg
-    - name: Deploy Nuget Package
-      run: dotnet nuget push ./artifacts/*.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y xorg-dev libwayland-dev libxkbcommon-dev wayland-protocols extra-cmake-modules curl wget git cmake
+          wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/powershell_7.4.0-1.deb_amd64.deb
+          dpkg -i powershell_7.4.0-1.deb_amd64.deb
+      - uses: actions/checkout@v3
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Download dependencies and create Nuget Package
+        run: ./make_nuget.ps1 "" ${{ github.run_number }}
+        shell: pwsh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: NugetPackage
+          path: ./artifacts/*.nupkg
+      - name: Deploy Nuget Package
+        run: dotnet nuget push ./artifacts/*.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Install build dependencies
         run: |
           apt-get install -y curl wget git cmake
-          wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.0/powershell_7.4.0-1.deb_amd64.deb
-          dpkg -i powershell_7.4.0-1.deb_amd64.deb
+          VERSION_ID=$(awk -F= '/^VERSION_ID=/{gsub(/"/, "", $2); print $2}' /etc/os-release)
+          wget -q https://packages.microsoft.com/config/debian/$VERSION_ID/packages-microsoft-prod.deb
+          dpkg -i packages-microsoft-prod.deb
+          apt-get update
+          apt-get install -y powershell
       - uses: actions/checkout@v3
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,9 @@ jobs:
   build:
     env:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-    
-    runs-on: ${{ matrix.os }}
     container: debian:oldoldstable
     strategy:
       fail-fast: true
-      matrix:
-        os: [ubuntu-latest]
 
     steps:
       - name: Install X11 dependencies


### PR DESCRIPTION
Some users of your game using OpenTK 4 had issues on older distributions running the game since the libglfw.so is build using ubuntu:latest (github action) which as of writing is 22.04 and uses GLIBC 2.34 which causes issues (won't create a window and crash) when used on systems that ship older versions of GLIBC.

So to future proof this and cause less issues with linux distributions that ship older versions of GLIBC we can now use the second last major version of debian (and the shipped GLIBC with it) to build libglfw.so for linux.

Using `strings libglfw.so.3.3 | grep GLIBC` one can see which GLIBC is that max requiert for libglfw
and using `ldd --version` one can check the currently installed version of GLIBC

and here is the tested build script on my fork
https://github.com/Th3Dilli/glfw-redist/actions/runs/7576529979/job/20635553545